### PR TITLE
combine ledcSetup() and ledcAttachPin() into ledcAttach() because of …

### DIFF
--- a/CameraWebServer/app_httpd.cpp
+++ b/CameraWebServer/app_httpd.cpp
@@ -1386,8 +1386,7 @@ void startCameraServer()
 void setupLedFlash(int pin) 
 {
     #if CONFIG_LED_ILLUMINATOR_ENABLED
-    ledcSetup(LED_LEDC_CHANNEL, 5000, 8);
-    ledcAttachPin(pin, LED_LEDC_CHANNEL);
+    ledcAttach(LED_LEDC_CHANNEL, 5000, 8);
     #else
     log_i("LED flash is disabled -> CONFIG_LED_ILLUMINATOR_ENABLED = 0");
     #endif


### PR DESCRIPTION
…migration from ESP 2.x to 3.0

combine ledcSetup() and ledcAttachPin() into ledcAttach()

https://docs.espressif.com/projects/arduino-esp32/en/latest/migration_guides/2.x_to_3.0.html